### PR TITLE
Fix missing MySQL driver version

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -27,6 +27,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-j</artifactId>
+            <version>8.1.0</version>
             <scope>runtime</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
## Summary
- set an explicit version for `mysql-connector-j`

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: vite permission denied)*
- `mvn test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847ddbc9f10832b930b8ac38ba8de07