### PR TITLE
Fix MySQL connector dependency

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -25,7 +25,7 @@
             <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>
         <dependency>
-            <groupId>mysql</groupId>
+            <groupId>com.mysql</groupId>
             <artifactId>mysql-connector-j</artifactId>
             <version>8.1.0</version>
             <scope>runtime</scope>


### PR DESCRIPTION
## Summary
- use the correct `com.mysql` groupId for the MySQL driver

## Testing
- `mvn -q package -DskipTests` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847debb6554832bad9515f3f757de2c